### PR TITLE
Correctly account for date timezone offsets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@travelnest/diem",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6378,9 +6378,9 @@
       "dev": true
     },
     "timezone-mock": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/timezone-mock/-/timezone-mock-1.0.11.tgz",
-      "integrity": "sha512-6953NFagcHjhNLZ6RP+X8vi2wLburuxZ5qyAXORVv0VceMMwFMtKAU+JJxAVToPHpbBwqCJr9eq1vCyY2OJZFw==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/timezone-mock/-/timezone-mock-1.0.18.tgz",
+      "integrity": "sha512-/q+TjPYR/tuW4gL2VZUmmSyVzun2ZFUMMFfmf4O82dZ1Yv8ymTk2lY7Ke2+dvy9bh+A27wlGUT0jKS1HZHdPIg==",
       "dev": true
     },
     "tmpl": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@travelnest/diem",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Seize the Date",
-  "main": "/build",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
   "scripts": {
-    "test": "./node_modules/.bin/jest --coverage",
-    "build": "./node_modules/.bin/tsc",
-    "lint": "./node_modules/.bin/tslint --project ./tsconfig.json"
+    "test": "jest --coverage",
+    "build": "tsc",
+    "lint": "tslint --project ./tsconfig.json"
   },
   "files": [
     "package.json",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/jest": "^24.9.0",
     "@types/node": "^13.1.8",
     "jest": "^25.2.7",
-    "timezone-mock": "^1.0.11",
+    "timezone-mock": "^1.0.18",
     "ts-jest": "^24.3.0",
     "tslint": "^5.20.1",
     "typescript": "^3.7.5"

--- a/src/diem.test.ts
+++ b/src/diem.test.ts
@@ -11,7 +11,8 @@ const TZ: TimeZone[] = [
 	'Europe/London',
 	'Brazil/East',
 	'US/Eastern',
-	'US/Pacific'
+	'US/Pacific',
+	'Australia/Adelaide'
 ];
 
 type AnyFn = (...a: any[]) => any;

--- a/src/diem.test.ts
+++ b/src/diem.test.ts
@@ -30,6 +30,15 @@ inAllTimezonesIt.each = <F extends AnyFn>(params: Array<Parameters<F>>) => (desc
 
 describe('Diem', () => {
 	describe('test construction', () => {
+
+		it('should handle midnight in BST', () => {
+			register('Europe/London');
+			// April 1st at Midnight
+			const inBST = new Date(2020, 3, 1, 0, 0, 0, 0);
+			expect(new Diem(inBST).toISOString()).toEqual('2020-04-01');
+			unregister();
+		});
+
 		inAllTimezonesIt('should default to today', () => {
 			const now = new Date();
 			const today = new Diem();

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ class Diem {
 	public toDate = () => new Date(this.toISOString());
 }
 
-Diem.prototype[inspect.custom] = function () {
+Diem.prototype[inspect.custom] = function() {
 	return this.toString();
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,16 @@
 import { inspect } from 'util';
 
 const zeroPad = (n: number) => n < 10 ? '0' + n : n.toString();
-const coerceUTC = (d: Date) => new Date(d.toISOString().substr(0, 10) + 'T00:00:00Z');
+const coerceUTC = (d: Date) => {
+	let noTz = d;
+	const utcOffset = d.getTimezoneOffset();
+	if (utcOffset < 0) {
+		noTz = new Date(d.getTime() + (d.getTimezoneOffset() * 60 * 1000) * -1);
+	} else if (utcOffset === 0) {
+		noTz = new Date(d.getTime() + (d.getTimezoneOffset() * 60 * 1000));
+	}
+	return new Date((noTz).toISOString().substr(0, 10) + 'T00:00:00Z');
+};
 
 class Diem {
 	private readonly midnightUTC: Date;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,6 @@ const coerceUTC = (d: Date) => {
 	const utcOffset = d.getTimezoneOffset();
 	if (utcOffset < 0) {
 		noTz = new Date(d.getTime() + (d.getTimezoneOffset() * 60 * 1000) * -1);
-	} else if (utcOffset === 0) {
-		noTz = new Date(d.getTime() + (d.getTimezoneOffset() * 60 * 1000));
 	}
 	return new Date((noTz).toISOString().substr(0, 10) + 'T00:00:00Z');
 };
@@ -68,7 +66,7 @@ class Diem {
 	public toDate = () => new Date(this.toISOString());
 }
 
-Diem.prototype[inspect.custom] = function() {
+Diem.prototype[inspect.custom] = function () {
 	return this.toString();
 };
 


### PR DESCRIPTION
Patch Diem functionality such that

`1st April 2020 00:00:00`, which is in British Summer Time, correctly outputs a `Diem` with `2020-04-01` as its date.