### PR TITLE
QOL improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+# Start of Travis job config
+language: node_js
+node_js:
+  - "12"
+stages:
+  - name: test
+    if: type = pull_request OR (type = push AND branch = master)
+jobs:
+  include:
+    # Test
+    - stage: test
+      install: npm ci
+      script: npm run build && npm run lint && npm t

--- a/src/diem.test.ts
+++ b/src/diem.test.ts
@@ -29,6 +29,10 @@ inAllTimezonesIt.each = <F extends AnyFn>(params: Array<Parameters<F>>) => (desc
 	});
 };
 
+// TODOJ NEXT:
+// * Add tests for constructing from Diem
+// * Add JSDoc for Diff method
+
 describe('Diem', () => {
 	describe('test construction', () => {
 
@@ -44,6 +48,15 @@ describe('Diem', () => {
 			const now = new Date();
 			const today = new Diem();
 			sameDies(now, today);
+		});
+
+		it('should create a new instance from a Diem', () => {
+			const june1st2020 = new Diem(2020, 5, 1);
+			expect(june1st2020.toISOString()).toEqual('2020-06-01');
+			const newOne = new Diem(june1st2020);
+
+			expect(newOne.toISOString()).toEqual('2020-06-01');
+			expect(newOne.toISOString()).not.toBe(june1st2020);
 		});
 
 		inAllTimezonesIt('should parse iso date strings', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import { inspect } from 'util';
 
 const zeroPad = (n: number) => n < 10 ? '0' + n : n.toString();
+
 const coerceUTC = (d: Date) => {
-	let noTz = d;
+	let noTz = new Date(d.getTime());
 	const utcOffset = d.getTimezoneOffset();
 	if (utcOffset < 0) {
 		noTz = new Date(d.getTime() + (d.getTimezoneOffset() * 60 * 1000) * -1);
@@ -13,13 +14,15 @@ const coerceUTC = (d: Date) => {
 class Diem {
 	private readonly midnightUTC: Date;
 
-	constructor(value?: number | string | Date);
+	constructor(value?: number | string | Date | Diem);
 	constructor(year: number, month: number, date?: number);
-	constructor(p1?: string | number | Date, p2?: number, p3?: number) {
+	constructor(p1?: string | number | Date | Diem, p2?: number, p3?: number) {
 		let midnightUTC: Date;
 
 		if (p1 instanceof Date) {
 			midnightUTC = coerceUTC(p1);
+		} else if (p1 instanceof Diem) {
+			midnightUTC = coerceUTC(p1.toDate());
 		} else if (typeof p1 === 'string') {
 			midnightUTC = new Date(p1.substr(0, 10) + 'T00:00:00Z');
 		} else if (typeof p1 === 'number' && p2 !== undefined) {
@@ -50,6 +53,21 @@ class Diem {
 		return this;
 	}
 
+	/**
+	 * Compare this Diem to another Diem (or Date).
+	 *
+	 * @param {Diem | Date} that - The date-like to compare to.
+	 *
+	 * @returns {number} diff - The number of days between "this" and "that".
+	 *
+	 * @example
+	 *
+	 * new Diem('2020-06-01').diff(new Diem('2020-06-10'))  // returns -9 (9 days before)
+	 *
+	 * new Diem('2020-06-01').diff(new Diem('2020-05-28'))  // returns 3 (3 days after)
+	 *
+	 * new Diem('2020-06-01').diff(new Diem('2020-06-01'))  // return 0 (same day)
+	 */
 	public diff = (that: Diem | Date) => {
 		const MS_IN_DAY = 1000 * 60 * 60 * 24;
 


### PR DESCRIPTION
Add support for constructing an instance from an existing `Diem`:

```
const june1st2020 = new Diem('2020-06-01');
new Diem(june1st2020);  // Returns a _new_ instance on the same date
```

## Also:
* add JSDoc to `Diem.diff` for easier understanding of its functionality
* Add travis config for PRs

